### PR TITLE
Filter needs to ignore objects

### DIFF
--- a/src/Client/Filter.php
+++ b/src/Client/Filter.php
@@ -85,7 +85,7 @@ class Filter implements ArrayAccess, Countable
             return '[' . $value->toIso8601String() . ']';
         }
 
-        if ((is_array($value)) || (is_integer($value))) {
+        if ((is_array($value)) || (is_integer($value)) || (is_object($value))) {
             return $value;
         }
 


### PR DESCRIPTION
I'm not 100% sure about this change, but it seems to fix things for me.  I am doing something like this:

```
    $contact = new Spinen\ConnectWise\Library\Api\Generated\Contact();
    $contact->setId(0)
            ->setFirstName($first)
            ->setLastName($last)
            ->setEmail($email)
            ->setPhone($phone);

    $q = $this->client->contactApiAddOrUpdateContact(["contact" => $contact]);
```

Without this change, one just gets:

PHP Warning:  addslashes() expects parameter 1 to be string, object given in /vagrant/php/vendor/spinen/connectwise-php-client/Filter.php on line 100
PHP Catchable fatal error:  Argument 1 passed to Spinen\ConnectWise\Library\Api\Generated\AddOrUpdateContact::setContact() must be an instance of Spinen\ConnectWise\Library\Api\Generated\Contact, string given, called in /vagrant/php/vendor/spinen/connectwise-php-client/Client.php on line 144 and defined in /vagrant/php/vendor/spinen/connectwise-php-library/Api/Generated/AddOrUpdateContact.php on line 58

Originally I tried sending just an array instead of a contact, but that throws:

PHP Catchable fatal error:  Argument 1 passed to Spinen\ConnectWise\Library\Api\Generated\AddOrUpdateContact::setContact() must be an instance of Spinen\ConnectWise\Library\Api\Generated\Contact, string given, called in /vagrant/php/vendor/spinen/connectwise-php-client/Client.php on line 144 and defined in /vagrant/php/vendor/spinen/connectwise-php-library/Api/Generated/AddOrUpdateContact.php on line 58
